### PR TITLE
Kms event queue

### DIFF
--- a/Assets/00.WorkSpace/KMS/Canvas/KMS_MainCanvas.prefab
+++ b/Assets/00.WorkSpace/KMS/Canvas/KMS_MainCanvas.prefab
@@ -2375,7 +2375,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 483}
+  m_AnchoredPosition: {x: 0, y: 450}
   m_SizeDelta: {x: 500, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3113093571201695137

--- a/Assets/00.WorkSpace/KMS/KMS_SampleScene 1.unity
+++ b/Assets/00.WorkSpace/KMS/KMS_SampleScene 1.unity
@@ -713,6 +713,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2499485383622922242, guid: 3cdd2966ce417654d81afa833936a750, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 450
+      objectReference: {fileID: 0}
     - target: {fileID: 4518999109263167989, guid: 3cdd2966ce417654d81afa833936a750, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0

--- a/Assets/00.WorkSpace/KMS/Script/Interface/ISaveService.cs
+++ b/Assets/00.WorkSpace/KMS/Script/Interface/ISaveService.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// ================================
+// Script  : ISaveService.cs
+// Desc    : 세이브기능 외부 API 계약
+// ================================
+
+public interface ISaveService
+{
+    GameData Data { get; }
+    bool LoadOrCreate();
+    void Save();
+    void ResetData();
+}

--- a/Assets/00.WorkSpace/KMS/Script/Interface/ISaveService.cs.meta
+++ b/Assets/00.WorkSpace/KMS/Script/Interface/ISaveService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7b25253396501b45b1d6d0a420b42ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00.WorkSpace/KMS/Script/Manager/UIManager.cs
+++ b/Assets/00.WorkSpace/KMS/Script/Manager/UIManager.cs
@@ -16,10 +16,13 @@ public class UIManager : MonoBehaviour, IManager
     [System.Serializable]
     public class PanelEntry
     {
-        public string key;          // "Pause", "Result" 등
-        public GameObject root;     // 패널 루트 오브젝트
+        public string key;                   // "Pause", "Result" 등
+        public GameObject root;              // 패널 루트 오브젝트
         public bool defaultActive = false;
         public bool useCanvasGroup = true;   // 페이드용
+        public bool isModal = false;         // 모달 여부
+        public bool closeOnEscape = true;    // ESC로 닫기 허용
+        public int baseSorting = 1000;       // 모달 기본 정렬
     }
 
     [Header("HUD")]
@@ -30,6 +33,7 @@ public class UIManager : MonoBehaviour, IManager
     [SerializeField] private List<PanelEntry> _panels = new();
 
     private readonly Dictionary<string, PanelEntry> _panelMap = new();
+    private readonly List<string> _modalOrder = new();
     private EventQueue _bus;
     private GameManager _game;
 
@@ -41,11 +45,30 @@ public class UIManager : MonoBehaviour, IManager
     {
         if (_bus == null || _game == null)
             Debug.LogError("[UIManager] SetDependencies 필요");
+
+        foreach (var p in _panels)
+        {
+            if (p.isModal && p.root)
+            {
+                var cv = p.root.GetComponent<Canvas>() ?? p.root.AddComponent<Canvas>();
+                cv.overrideSorting = true;
+
+                var cg = p.root.GetComponent<CanvasGroup>() ?? p.root.AddComponent<CanvasGroup>();
+                cg.blocksRaycasts = false;
+                cg.interactable = false;
+
+                // 레이캐스터 없으면 추가 (클릭/차단을 위해 필요)
+                if (!p.root.GetComponent<UnityEngine.UI.GraphicRaycaster>())
+                    p.root.AddComponent<UnityEngine.UI.GraphicRaycaster>();
+            }
+        }
     }
 
     public void Init()
     {
         _panelMap.Clear();
+        _modalOrder.Clear();
+
         foreach (var p in _panels)
         {
             if (p.root) p.root.SetActive(p.defaultActive);
@@ -59,6 +82,12 @@ public class UIManager : MonoBehaviour, IManager
         _bus.Subscribe<ScoreChanged>(e => { if (_scoreText) _scoreText.text = e.value.ToString(); }, replaySticky: true);
         _bus.Subscribe<ComboChanged>(e => { if (_comboText) _comboText.text = $"x{e.value}"; }, replaySticky: true);
 
+        // GameOver 들어오면 모달 오픈(Sticky → 초기에도 즉시 반응)
+        _bus.Subscribe<GameOver>(_ => SetPanel("GameOver", true), replaySticky: true);
+
+        // 광고 성공 시 모달 닫기
+        _bus.Subscribe<ContinueGranted>(_ => SetPanel("GameOver", false), replaySticky: false);
+
         // 패널 토글 이벤트 구독 (원하면 버튼에서 직접 API 호출해도 됨)
         _bus.Subscribe<PanelToggle>(OnPanelToggle, replaySticky: false);
     }
@@ -70,20 +99,28 @@ public class UIManager : MonoBehaviour, IManager
     {
         if (!_panelMap.TryGetValue(key, out var p) || p.root == null) return;
 
+        // 모달이면 LIFO 경로로
+        if (p.isModal)
+        {
+            if (on) PushModalInternal(key);
+            else PopModalInternal(key);
+            return;
+        }
+
+        // 일반 패널: 기존처럼 페이드/온오프
         if (!p.useCanvasGroup)
         {
             p.root.SetActive(on);
             return;
         }
 
-        // CanvasGroup 페이드 (선택)
         var cg = p.root.GetComponent<CanvasGroup>() ?? p.root.AddComponent<CanvasGroup>();
         if (!p.root.activeSelf) { p.root.SetActive(true); cg.alpha = 0f; }
         StopAllCoroutines();
         StartCoroutine(FadeRoutine(cg, on ? 1f : 0f, 0.15f, on));
     }
 
-    private System.Collections.IEnumerator FadeRoutine(CanvasGroup cg, float target, float dur, bool finalActive)
+    private IEnumerator FadeRoutine(CanvasGroup cg, float target, float dur, bool finalActive)
     {
         float t = 0f; float start = cg.alpha;
         while (t < dur)
@@ -94,6 +131,80 @@ public class UIManager : MonoBehaviour, IManager
         }
         cg.alpha = target;
         if (!finalActive) cg.gameObject.SetActive(false);
+    }
+    public void CloseTopModal()
+    {
+        if (_modalOrder.Count == 0) return;
+        PopModalInternal(_modalOrder[^1]);
+    }
+    public bool TryCloseTopByEscape()
+    {
+        if (_modalOrder.Count == 0) return false;
+        var topKey = _modalOrder[^1];
+        if (_panelMap.TryGetValue(topKey, out var p) && !p.closeOnEscape) return false;
+        PopModalInternal(topKey);
+        return true;
+    }
+
+    // === 내부: 모달 LIFO ===
+    private void PushModalInternal(string key)
+    {
+        if (!_panelMap.TryGetValue(key, out var p) || p.root == null) return;
+
+        // 중복 제거 후 맨 위로
+        int idx = _modalOrder.IndexOf(key);
+        if (idx >= 0) _modalOrder.RemoveAt(idx);
+        _modalOrder.Add(key);
+
+        // 켜기 (모달도 페이드 쓰고 싶으면 CanvasGroup 활용)
+        if (p.useCanvasGroup)
+        {
+            var cg = p.root.GetComponent<CanvasGroup>() ?? p.root.AddComponent<CanvasGroup>();
+            if (!p.root.activeSelf) { p.root.SetActive(true); cg.alpha = 0f; }
+            StopAllCoroutines();
+            StartCoroutine(FadeRoutine(cg, 1f, 0.12f, true));
+        }
+        else p.root.SetActive(true);
+
+        ReorderModals();
+    }
+
+    private void PopModalInternal(string key)
+    {
+        int idx = _modalOrder.LastIndexOf(key);
+        if (idx < 0) return;
+
+        _modalOrder.RemoveAt(idx);
+        if (_panelMap.TryGetValue(key, out var p) && p.root)
+        {
+            if (p.useCanvasGroup)
+            {
+                var cg = p.root.GetComponent<CanvasGroup>() ?? p.root.AddComponent<CanvasGroup>();
+                StopAllCoroutines();
+                StartCoroutine(FadeRoutine(cg, 0f, 0.12f, false));
+            }
+            else p.root.SetActive(false);
+        }
+
+        ReorderModals();
+    }
+
+    private void ReorderModals()
+    {
+        // 최상단만 입력/Raycast, 정렬은 baseSorting + depth*10
+        for (int i = 0; i < _modalOrder.Count; i++)
+        {
+            var k = _modalOrder[i];
+            var p = _panelMap[k];
+            var cv = p.root.GetComponent<Canvas>() ?? p.root.AddComponent<Canvas>();
+            cv.overrideSorting = true;
+            cv.sortingOrder = p.baseSorting + (i + 1) * 10;
+
+            var cg = p.root.GetComponent<CanvasGroup>() ?? p.root.AddComponent<CanvasGroup>();
+            bool top = (i == _modalOrder.Count - 1);
+            cg.blocksRaycasts = top;
+            cg.interactable = top;
+        }
     }
 }
 

--- a/Assets/00.WorkSpace/KMS/Script/System/AppLifecycleEmitter.cs
+++ b/Assets/00.WorkSpace/KMS/Script/System/AppLifecycleEmitter.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// ================================
+// Script  : AppLifecycleEmitter.cs
+// Desc    : 일시정지/종료 시 자동 저장
+// ================================
+
+[DefaultExecutionOrder(-1000)]
+public sealed class AppLifecycleEmitter : MonoBehaviour
+{
+    void OnApplicationPause(bool pause)
+    {
+        if (pause && Game.IsBound) Game.Bus.Publish(new SaveRequested());
+    }
+    void OnApplicationQuit()
+    {
+        if (Game.IsBound) Game.Bus.Publish(new SaveRequested());
+    }
+}

--- a/Assets/00.WorkSpace/KMS/Script/System/AppLifecycleEmitter.cs.meta
+++ b/Assets/00.WorkSpace/KMS/Script/System/AppLifecycleEmitter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c06c0990f8bca04fbb30693ff67c596
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00.WorkSpace/KMS/Script/System/EventQueue.cs
+++ b/Assets/00.WorkSpace/KMS/Script/System/EventQueue.cs
@@ -194,3 +194,11 @@ public sealed class EventQueue : IManager, ITickable, ITeardown
 // 샘플 이벤트
 public readonly struct ScoreChanged { public readonly int value; public ScoreChanged(int v) => value = v; }
 public readonly struct ComboChanged { public readonly int value; public ComboChanged(int v) => value = v; }
+public readonly struct GameOver
+{
+    public readonly int score; public readonly string reason;
+    public GameOver(int score, string reason = null) { this.score = score; this.reason = reason; }
+}
+
+public readonly struct RewardedContinueRequest { }      // 명령(Non-Sticky)
+public readonly struct ContinueGranted { }              // 명령 결과

--- a/Assets/00.WorkSpace/KMS/Script/System/EventQueue.cs
+++ b/Assets/00.WorkSpace/KMS/Script/System/EventQueue.cs
@@ -202,3 +202,12 @@ public readonly struct GameOver
 
 public readonly struct RewardedContinueRequest { }      // 명령(Non-Sticky)
 public readonly struct ContinueGranted { }              // 명령 결과
+public readonly struct SaveRequested { }
+public readonly struct LoadRequested { }
+public readonly struct ResetRequested { }
+
+public readonly struct GameDataChanged
+{
+    public readonly GameData data;
+    public GameDataChanged(GameData d) { data = d; }
+}

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,3 +8,5 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/00.WorkSpace/KMS/KMS_SampleScene 1.unity
     guid: 7c63392f67002ac45893a289526842d3
+  m_configObjects:
+    com.unity.addressableassets: {fileID: 11400000, guid: b7e57973263d1a847b0ae0f85be3e4fd, type: 2}

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,4 +8,3 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/00.WorkSpace/KMS/KMS_SampleScene 1.unity
     guid: 7c63392f67002ac45893a289526842d3
-  m_configObjects: {}


### PR DESCRIPTION
## 요약
---
- Wire **GameOver → UI modal** via **sticky state**
- Introduce **internal LIFO** for modal handling in `UIManager`
- Fix **MainCanvas title position**


## 변경점
---
- feat(ui): `UIManager` 모달 LIFO 정렬/입력 차단/ESC 정책, `SetPanel(key,on)` 라우팅
- feat(core): `GameOver` 이벤트를 **Sticky**로 발행(초기 표시 보장)
- fix(ui): MainCanvas 타이틀 앵커/오프셋 보정

## 배경/의도 (Why)
---
- 상태=Sticky / 명령=Non-Sticky 규약 정착
- 모달 우선순위/입력 차단 보장(일관된 UX)
- 해상도 변경 시 레이아웃 안정화

## 테스트 플랜 (How to test)
---
1. 실행 시 `=== Game.Bind Report ===` OK
2. `TriggerGameOver()` 호출 → GameOver 모달 즉시 표시(Sticky 재생)
3. 모달 A → 모달 B → **B가 최상단**, ESC → B만 닫힘
4. GameOver 모달은 `closeOnEscape=false`로 ESC 무시
5. 타이틀 위치: 16:9 / 18:9 / 4:3에서 정상

호환성/리스크 (Risks)
---
- Perf: 이벤트 빈도 낮음, GC 스파이크 없음(Profiler 확인)
- Risk: UIManager LIFO 도입으로 패널 키 오타/누락 시 미표시 가능 → 인스펙터 검증