### PR TITLE
[Fix] 버튼 상태에 따라 PanelSwitchOnClick의 활성화 여부 설정

### DIFF
--- a/Assets/00.WorkSpace/GIL/Prefabs/Adventure/Stage_N_Button.prefab
+++ b/Assets/00.WorkSpace/GIL/Prefabs/Adventure/Stage_N_Button.prefab
@@ -285,6 +285,7 @@ MonoBehaviour:
   stageButtonImage: {fileID: 2369435605088257752}
   button: {fileID: 8778948114370188760}
   buttonText: {fileID: 5206756636522517261}
+  panelSwitch: {fileID: 3735727100625425493}
   normalSprite: {fileID: 21300000, guid: a3e78e8e524040741afd3634bc3ebfe3, type: 3}
   activeSprite: {fileID: 21300000, guid: d3825727bc72c7c4d81a5cfa788493a9, type: 3}
   clearSprite: {fileID: 0}
@@ -316,7 +317,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8248359133486922377}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 68ef6b8dfc9409c4293251e938943853, type: 3}
   m_Name: 

--- a/Assets/00.WorkSpace/GIL/Scripts/Stages/EnterStageButton.cs
+++ b/Assets/00.WorkSpace/GIL/Scripts/Stages/EnterStageButton.cs
@@ -83,14 +83,17 @@ public class EnterStageButton : MonoBehaviour
         {
             case ButtonState.Cleared:
                 stageButtonImage.sprite = clearSprite;
+                GetComponent<PanelSwitchOnClick>().enabled = false;
                 buttonText.enabled = false;
                 break;
             case ButtonState.Playable:
                 stageButtonImage.sprite = activeSprite;
+                GetComponent<PanelSwitchOnClick>().enabled = true;
                 buttonText.enabled = false;
                 break;
             case ButtonState.Locked:
                 stageButtonImage.sprite = normalSprite;
+                GetComponent<PanelSwitchOnClick>().enabled = false;
                 buttonText.enabled = true;
                 break;
         }


### PR DESCRIPTION
- 이슈
- 잠금 상태인 버튼을 클릭했을 때 빈 스테이지로 들어가는 현상 발견
- 원인
- PanelSwtichOnClick의 IPointerClick이 상시 활성화되어서 발생하는 문제
- 해결
- 상태에 따라 활성화 여부를 결정, 기본적으로 비활성화 상태를 유지